### PR TITLE
Feature/newer gcc compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 # HAPCUT2 MAKEFILE
 default: all
 
-CC=gcc -g -O3 -Wall -D_GNU_SOURCE
-CFLAGS=-Wall
+CFLAGS=-Wall -g -O3 -Wall -D_GNU_SOURCE
 
 # DIRECTORIES
 B=build

--- a/hairs-src/hashtable.c
+++ b/hairs-src/hashtable.c
@@ -39,7 +39,7 @@ int insert_keyvalue(HASHTABLE* ht, char* key, int slen, int value) {
 
 int getindex(HASHTABLE* ht, char* chrom) {
     int hash = hashstring(chrom, ht->htsize);
-    keypointer = ht->blist[hash];
+    keyvalue* keypointer = ht->blist[hash];
     while (keypointer != NULL) {
         if (strcmp(keypointer->key, chrom) == 0) return keypointer->value;
         keypointer = keypointer->next;

--- a/hairs-src/hashtable.h
+++ b/hairs-src/hashtable.h
@@ -13,7 +13,7 @@ typedef struct keyvalue {
     struct keyvalue* next;
 } keyvalue;
 
-keyvalue* keypointer;
+extern keyvalue* keypointer;
 
 typedef struct HASHTABLE {
     int htsize; // prime number that is also the size of HASHTABLE


### PR DESCRIPTION
The first commit adds in some changes that fix errors with newer gcc versions.

The second commit changes the Makefile a little bit, I removed the line defining the CC variable, in favor of the contents of that variable in the environment, I moved most of the flags defined there to the CFLAGS variable.